### PR TITLE
Python Color Annotator

### DIFF
--- a/pipeline/build.gradle
+++ b/pipeline/build.gradle
@@ -18,7 +18,7 @@
 apply plugin: 'application'
 mainClassName = 'org.ros.RosRun'
 
-/* 
+/*
  Dependencies can be on external maven artifacts (such as rosjava_core
  here) or on sibling subprojects. Fpr external maven artifact dependencies
  it's convenient to use an open ranged dependency, but restrict it to
@@ -32,10 +32,12 @@ targetCompatibility = 1.8
 dependencies {
   /* An external maven artifact dependency */
   compile 'org.ros.rosjava_core:rosjava:[0.2,0.3)'
-  /* Example of a local subproject dependency */ 
+  /* Example of a local subproject dependency */
   /* compile project(':sibling_gradle_project') */
 
   // https://mvnrepository.com/artifact/org.apache.uima/uimaj-core
   compile group: 'org.apache.uima', name: 'uimaj-core', version: '2.10.1'
-}
 
+  // https://mvnrepository.com/artifact/org.apache.uima/uimaj-json
+  compile group: 'org.apache.uima', name: 'uimaj-json', version: '2.10.1'
+}

--- a/pipeline/build.gradle
+++ b/pipeline/build.gradle
@@ -40,4 +40,7 @@ dependencies {
 
   // https://mvnrepository.com/artifact/org.apache.uima/uimaj-json
   compile group: 'org.apache.uima', name: 'uimaj-json', version: '2.10.1'
+  
+  // https://mvnrepository.com/artifact/org.json/json
+  compile group: 'org.json', name: 'json', version: '20170516'
 }

--- a/pipeline/desc/ColorsAnnotatorDescriptor.xml
+++ b/pipeline/desc/ColorsAnnotatorDescriptor.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<analysisEngineDescription xmlns="http://uima.apache.org/resourceSpecifier">
+  <frameworkImplementation>org.apache.uima.java</frameworkImplementation>
+  <primitive>true</primitive>  <annotatorImplementationName/>
+  <analysisEngineMetaData>
+    <name>FindColorsAnnotatorDescriptor</name>
+    <description/>
+    <version>1.0</version>
+    <vendor/>
+    <configurationParameters/>
+    <configurationParameterSettings/>
+    <typeSystemDescription>
+      <types>
+        <typeDescription>
+          <name>edu.rosehulman.aixprize.pipeline.types.Color</name>
+          <description/>
+          <supertypeName>uima.tcas.Annotation</supertypeName>
+          <features>
+            <featureDescription>
+              <name>name</name>
+              <description/>
+              <rangeTypeName>uima.cas.String</rangeTypeName>
+            </featureDescription>
+          </features>
+        </typeDescription>
+      </types>
+    </typeSystemDescription>
+    <typePriorities/>
+    <fsIndexCollection/>
+    <capabilities>
+      <capability>
+        <inputs/>
+        <outputs/>
+        <languagesSupported/>
+      </capability>
+    </capabilities>
+  <operationalProperties>
+      <modifiesCas>true</modifiesCas>
+      <multipleDeploymentAllowed>true</multipleDeploymentAllowed>
+      <outputsNewCASes>false</outputsNewCASes>
+    </operationalProperties>
+  </analysisEngineMetaData>
+  <resourceManagerConfiguration/>
+</analysisEngineDescription>

--- a/pipeline/desc/ColorsAnnotatorDescriptor.xml
+++ b/pipeline/desc/ColorsAnnotatorDescriptor.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <analysisEngineDescription xmlns="http://uima.apache.org/resourceSpecifier">
   <frameworkImplementation>org.apache.uima.java</frameworkImplementation>
-  <primitive>true</primitive>  <annotatorImplementationName/>
+  <primitive>true</primitive>  <annotatorImplementationName>edu.rosehulman.aixprize.pipeline.annotators.ColorsAnnotator</annotatorImplementationName>
   <analysisEngineMetaData>
     <name>FindColorsAnnotatorDescriptor</name>
     <description/>

--- a/pipeline/src/main/java/edu/rosehulman/aixprize/pipeline/annotators/ColorsAnnotator.java
+++ b/pipeline/src/main/java/edu/rosehulman/aixprize/pipeline/annotators/ColorsAnnotator.java
@@ -1,0 +1,27 @@
+package edu.rosehulman.aixprize.pipeline.annotators;
+
+import java.io.*;
+import java.net.Socket;
+
+import org.apache.uima.analysis_component.JCasAnnotator_ImplBase;
+import org.apache.uima.analysis_engine.AnalysisEngineProcessException;
+import org.apache.uima.jcas.JCas;
+import org.apache.uima.json.JsonCasSerializer;
+
+
+public class ColorsAnnotator extends JCasAnnotator_ImplBase {
+
+	@Override
+	public void process(JCas cas) throws AnalysisEngineProcessException {
+		try {
+			StringWriter serialized = new StringWriter();
+			JsonCasSerializer.jsonSerialize(cas.getCas(), serialized);
+			
+			Socket socket = new Socket("127.0.0.1", 8080);
+			socket.getOutputStream().write(serialized.toString().getBytes());
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
+
+}

--- a/pipeline/src/main/java/edu/rosehulman/aixprize/pipeline/annotators/ColorsAnnotator.java
+++ b/pipeline/src/main/java/edu/rosehulman/aixprize/pipeline/annotators/ColorsAnnotator.java
@@ -1,46 +1,79 @@
 package edu.rosehulman.aixprize.pipeline.annotators;
 
 import java.io.*;
-import java.net.Socket;
-import java.util.List;
+import java.net.*;
 
+import org.apache.uima.UimaContext;
 import org.apache.uima.analysis_component.JCasAnnotator_ImplBase;
 import org.apache.uima.analysis_engine.AnalysisEngineProcessException;
-import org.apache.uima.cas.CAS;
 import org.apache.uima.jcas.JCas;
 import org.apache.uima.jcas.tcas.Annotation;
 import org.apache.uima.json.JsonCasSerializer;
-import org.json.*;
+import org.apache.uima.resource.ResourceInitializationException;
+import org.json.JSONObject;
+
+import edu.rosehulman.aixprize.pipeline.types.Color;
 
 public class ColorsAnnotator extends JCasAnnotator_ImplBase {
+	
+	private Socket socket;
 
 	@Override
-	public void process(JCas cas) throws AnalysisEngineProcessException {
+	public void initialize(UimaContext aContext) throws ResourceInitializationException {
 		try {
-			Socket socket = new Socket("127.0.0.1", 8080);
-			transmitCas(cas.getCas(), socket);
-			List<Annotation> annotations = receiveAnnotations(socket);
+			socket = new Socket("127.0.0.1", 8080);
 		} catch (IOException e) {
 			e.printStackTrace();
 		}
 	}
 
-	private void transmitCas(CAS cas, Socket socket) throws IOException {
+	@Override
+	public void process(JCas cas) throws AnalysisEngineProcessException {
+		if (socket == null) {
+			return;
+		}
+
+		try {
+			transmitCas(cas);
+			receiveAnnotations(cas);
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
+
+	private void transmitCas(JCas cas) throws IOException {
 		StringWriter serialized = new StringWriter();
-		JsonCasSerializer.jsonSerialize(cas, serialized);
-		
+		JsonCasSerializer.jsonSerialize(cas.getCas(), serialized);
+
 		socket.getOutputStream().write(serialized.toString().getBytes());
 	}
-	
-	private List<Annotation> receiveAnnotations(Socket socket) throws IOException {
-		BufferedReader reader 
+
+	private void receiveAnnotations(JCas cas) throws IOException {
+		BufferedReader reader
 			= new BufferedReader(new InputStreamReader(socket.getInputStream()));
-		String line;
-		
-		while ((line = reader.readLine()) != null) {
-			JSONObject object = new JSONObject(line);
+		Annotation annotation;
+		JSONObject annotationJson;
+
+		while (true) {
+			annotationJson = new JSONObject(reader.readLine());
+			if (annotationJson.names().length() == 0) {
+				break;
+			}
+
+			annotation = createAnnotation(cas, annotationJson);
+
+			annotation.setBegin(annotationJson.getInt("begin"));
+			annotation.setEnd(annotationJson.getInt("end"));
+
+			annotation.addToIndexes();
 		}
-		
-		return null;
+	}
+
+	private Annotation createAnnotation(JCas cas, JSONObject annotationJson) {
+		Color annotation = new Color(cas);
+
+		annotation.setName(annotationJson.getString("name"));
+
+		return annotation;
 	}
 }

--- a/pipeline/src/main/java/edu/rosehulman/aixprize/pipeline/annotators/ColorsAnnotator.java
+++ b/pipeline/src/main/java/edu/rosehulman/aixprize/pipeline/annotators/ColorsAnnotator.java
@@ -14,6 +14,16 @@ import org.json.JSONObject;
 
 import edu.rosehulman.aixprize.pipeline.types.Color;
 
+/**
+ * Communicates with a Python script to find color words in a file.
+ * Interface:
+ * - writes a standard JSON-ified CAS to the Socket at port 8080
+ * - receives a series of annotations in JSON, one per line, with fields of:
+ *   + begin: int
+ *   + end: int
+ *   + name: String
+ * - the last annotation line should be an empty JSON object
+ */
 public class ColorsAnnotator extends JCasAnnotator_ImplBase {
 	
 	private Socket socket;

--- a/pipeline/src/main/java/edu/rosehulman/aixprize/pipeline/annotators/ColorsAnnotator.java
+++ b/pipeline/src/main/java/edu/rosehulman/aixprize/pipeline/annotators/ColorsAnnotator.java
@@ -2,26 +2,45 @@ package edu.rosehulman.aixprize.pipeline.annotators;
 
 import java.io.*;
 import java.net.Socket;
+import java.util.List;
 
 import org.apache.uima.analysis_component.JCasAnnotator_ImplBase;
 import org.apache.uima.analysis_engine.AnalysisEngineProcessException;
+import org.apache.uima.cas.CAS;
 import org.apache.uima.jcas.JCas;
+import org.apache.uima.jcas.tcas.Annotation;
 import org.apache.uima.json.JsonCasSerializer;
-
+import org.json.*;
 
 public class ColorsAnnotator extends JCasAnnotator_ImplBase {
 
 	@Override
 	public void process(JCas cas) throws AnalysisEngineProcessException {
 		try {
-			StringWriter serialized = new StringWriter();
-			JsonCasSerializer.jsonSerialize(cas.getCas(), serialized);
-			
 			Socket socket = new Socket("127.0.0.1", 8080);
-			socket.getOutputStream().write(serialized.toString().getBytes());
+			transmitCas(cas.getCas(), socket);
+			List<Annotation> annotations = receiveAnnotations(socket);
 		} catch (IOException e) {
 			e.printStackTrace();
 		}
 	}
 
+	private void transmitCas(CAS cas, Socket socket) throws IOException {
+		StringWriter serialized = new StringWriter();
+		JsonCasSerializer.jsonSerialize(cas, serialized);
+		
+		socket.getOutputStream().write(serialized.toString().getBytes());
+	}
+	
+	private List<Annotation> receiveAnnotations(Socket socket) throws IOException {
+		BufferedReader reader 
+			= new BufferedReader(new InputStreamReader(socket.getInputStream()));
+		String line;
+		
+		while ((line = reader.readLine()) != null) {
+			JSONObject object = new JSONObject(line);
+		}
+		
+		return null;
+	}
 }

--- a/pipeline/src/main/java/edu/rosehulman/aixprize/pipeline/types/Color.java
+++ b/pipeline/src/main/java/edu/rosehulman/aixprize/pipeline/types/Color.java
@@ -1,0 +1,101 @@
+
+
+/* First created by JCasGen Sun Oct 08 07:47:26 EDT 2017 */
+package edu.rosehulman.aixprize.pipeline.types;
+
+import org.apache.uima.jcas.JCas; 
+import org.apache.uima.jcas.JCasRegistry;
+import org.apache.uima.jcas.cas.TOP_Type;
+
+import org.apache.uima.jcas.tcas.Annotation;
+
+
+/** 
+ * Updated by JCasGen Sun Oct 08 07:47:26 EDT 2017
+ * XML source: /mnt/ubuntu/home/lewis/aixprize_ws/src/edu_rosehulman_aixprize/pipeline/desc/FindColorsAnnotatorDescriptor.xml
+ * @generated */
+public class Color extends Annotation {
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static int typeIndexID = JCasRegistry.register(Color.class);
+  /** @generated
+   * @ordered 
+   */
+  @SuppressWarnings ("hiding")
+  public final static int type = typeIndexID;
+  /** @generated
+   * @return index of the type  
+   */
+  @Override
+  public              int getTypeIndexID() {return typeIndexID;}
+ 
+  /** Never called.  Disable default constructor
+   * @generated */
+  protected Color() {/* intentionally empty block */}
+    
+  /** Internal - constructor used by generator 
+   * @generated
+   * @param addr low level Feature Structure reference
+   * @param type the type of this Feature Structure 
+   */
+  public Color(int addr, TOP_Type type) {
+    super(addr, type);
+    readObject();
+  }
+  
+  /** @generated
+   * @param jcas JCas to which this Feature Structure belongs 
+   */
+  public Color(JCas jcas) {
+    super(jcas);
+    readObject();   
+  } 
+
+  /** @generated
+   * @param jcas JCas to which this Feature Structure belongs
+   * @param begin offset to the begin spot in the SofA
+   * @param end offset to the end spot in the SofA 
+  */  
+  public Color(JCas jcas, int begin, int end) {
+    super(jcas);
+    setBegin(begin);
+    setEnd(end);
+    readObject();
+  }   
+
+  /** 
+   * <!-- begin-user-doc -->
+   * Write your own initialization here
+   * <!-- end-user-doc -->
+   *
+   * @generated modifiable 
+   */
+  private void readObject() {/*default - does nothing empty block */}
+     
+ 
+    
+  //*--------------*
+  //* Feature: name
+
+  /** getter for name - gets 
+   * @generated
+   * @return value of the feature 
+   */
+  public String getName() {
+    if (Color_Type.featOkTst && ((Color_Type)jcasType).casFeat_name == null)
+      jcasType.jcas.throwFeatMissing("name", "edu.rosehulman.aixprize.pipeline.types.Color");
+    return jcasType.ll_cas.ll_getStringValue(addr, ((Color_Type)jcasType).casFeatCode_name);}
+    
+  /** setter for name - sets  
+   * @generated
+   * @param v value to set into the feature 
+   */
+  public void setName(String v) {
+    if (Color_Type.featOkTst && ((Color_Type)jcasType).casFeat_name == null)
+      jcasType.jcas.throwFeatMissing("name", "edu.rosehulman.aixprize.pipeline.types.Color");
+    jcasType.ll_cas.ll_setStringValue(addr, ((Color_Type)jcasType).casFeatCode_name, v);}    
+  }
+
+    

--- a/pipeline/src/main/java/edu/rosehulman/aixprize/pipeline/types/Color_Type.java
+++ b/pipeline/src/main/java/edu/rosehulman/aixprize/pipeline/types/Color_Type.java
@@ -1,0 +1,69 @@
+
+/* First created by JCasGen Sun Oct 08 07:47:26 EDT 2017 */
+package edu.rosehulman.aixprize.pipeline.types;
+
+import org.apache.uima.jcas.JCas;
+import org.apache.uima.jcas.JCasRegistry;
+import org.apache.uima.cas.impl.TypeImpl;
+import org.apache.uima.cas.Type;
+import org.apache.uima.cas.impl.FeatureImpl;
+import org.apache.uima.cas.Feature;
+import org.apache.uima.jcas.tcas.Annotation_Type;
+
+/** 
+ * Updated by JCasGen Sun Oct 08 07:47:26 EDT 2017
+ * @generated */
+public class Color_Type extends Annotation_Type {
+  /** @generated */
+  @SuppressWarnings ("hiding")
+  public final static int typeIndexID = Color.typeIndexID;
+  /** @generated 
+     @modifiable */
+  @SuppressWarnings ("hiding")
+  public final static boolean featOkTst = JCasRegistry.getFeatOkTst("edu.rosehulman.aixprize.pipeline.types.Color");
+ 
+  /** @generated */
+  final Feature casFeat_name;
+  /** @generated */
+  final int     casFeatCode_name;
+  /** @generated
+   * @param addr low level Feature Structure reference
+   * @return the feature value 
+   */ 
+  public String getName(int addr) {
+        if (featOkTst && casFeat_name == null)
+      jcas.throwFeatMissing("name", "edu.rosehulman.aixprize.pipeline.types.Color");
+    return ll_cas.ll_getStringValue(addr, casFeatCode_name);
+  }
+  /** @generated
+   * @param addr low level Feature Structure reference
+   * @param v value to set 
+   */    
+  public void setName(int addr, String v) {
+        if (featOkTst && casFeat_name == null)
+      jcas.throwFeatMissing("name", "edu.rosehulman.aixprize.pipeline.types.Color");
+    ll_cas.ll_setStringValue(addr, casFeatCode_name, v);}
+    
+  
+
+
+
+  /** initialize variables to correspond with Cas Type and Features
+	 * @generated
+	 * @param jcas JCas
+	 * @param casType Type 
+	 */
+  public Color_Type(JCas jcas, Type casType) {
+    super(jcas, casType);
+    casImpl.getFSClassRegistry().addGeneratorForType((TypeImpl)this.casType, getFSGenerator());
+
+ 
+    casFeat_name = jcas.getRequiredFeatureDE(casType, "name", "uima.cas.String", featOkTst);
+    casFeatCode_name  = (null == casFeat_name) ? JCas.INVALID_FEATURE_CODE : ((FeatureImpl)casFeat_name).getCode();
+
+  }
+}
+
+
+
+    

--- a/pipeline/src/resources/Client.py
+++ b/pipeline/src/resources/Client.py
@@ -1,0 +1,16 @@
+
+import socket
+
+# host = socket.gethostname()
+host = '127.0.0.1'
+port = 12345                   # The same port as used by the server
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+print('Connecting')
+s.connect((host, port))
+print('Connected')
+s.sendall(b'{"Hello": "world"}')
+print('Sent')
+data = s.recv(1024)
+print('Received')
+s.close()
+print('Received', repr(data))

--- a/pipeline/src/resources/ColorAnnotator.py
+++ b/pipeline/src/resources/ColorAnnotator.py
@@ -1,0 +1,39 @@
+
+import tornado.web
+import socket
+import tornado.ioloop
+import json
+
+class Annotator(tornado.web.RequestHandler):
+    def __init__(self):
+        self._addr = '127.0.0.1'
+        self._port = 8080
+        self._stream = None
+
+    def _initialize(self):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0)
+        self._stream = tornado.iostream.IOStream(sock)
+        self._stream.connect((self._addr, self._port))
+
+    def _handle_request(self):
+        self._stream.read_until('}', callback=self._annotate)
+
+    def _annotate(self, data):
+        resp = self.annotate(json.reads(data))
+        self.respond(resp)
+
+    def respond(self, data):
+        self._stream.write(json.dumps(data))
+
+
+class ColorAnnotator(Annotator):
+    def __init__(self):
+        super().__init__()
+        self.color_words = ['red', 'blue', 'yellow']
+
+    def annotate(self, data):
+        return {
+            'color': 'red',
+            'begin': 5,
+            'end': 10
+        }

--- a/pipeline/src/resources/ColorAnnotator.py
+++ b/pipeline/src/resources/ColorAnnotator.py
@@ -4,26 +4,41 @@ import socket
 import tornado.ioloop
 import json
 
+
 class Annotator(tornado.web.RequestHandler):
     def __init__(self):
-        self._addr = '127.0.0.1'
-        self._port = 8080
+        self._addr = ''
+        self._port = 12345
         self._stream = None
 
-    def _initialize(self):
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0)
-        self._stream = tornado.iostream.IOStream(sock)
-        self._stream.connect((self._addr, self._port))
+    def _initialize(self, sock):
+        client_socket, _ = sock.accept()
+        self._stream = tornado.iostream.IOStream(client_socket)
+        # self._stream.connect((self._addr, self._port))
 
-    def _handle_request(self):
-        self._stream.read_until('}', callback=self._annotate)
+    def _handle_request(self, sock, fd, events):
+        self._initialize(sock)
+        self._stream.read_until(b'}', callback=self._annotate)
 
     def _annotate(self, data):
-        resp = self.annotate(json.reads(data))
+        resp = self.annotate(json.loads(data))
         self.respond(resp)
 
     def respond(self, data):
-        self._stream.write(json.dumps(data))
+        print(data)
+        self._stream.write(bytes(json.dumps(data), 'UTF-8'))
+
+    def start(self):
+        print('Starting annotator')
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0)
+        sock.bind((self._addr, self._port))
+        sock.listen(5)
+
+        io_loop = tornado.ioloop.IOLoop.current()
+        io_loop.add_handler(sock.fileno(),
+                            lambda fd, events: self._handle_request(sock, fd, events),
+                            io_loop.READ)
+        io_loop.start()
 
 
 class ColorAnnotator(Annotator):
@@ -37,3 +52,8 @@ class ColorAnnotator(Annotator):
             'begin': 5,
             'end': 10
         }
+
+
+if __name__ == '__main__':
+    annotator = ColorAnnotator()
+    annotator.start()


### PR DESCRIPTION
The beginnings of a Python color annotator. You will need to do `pip3 install tornado` to get it to work, and you can run it with `python ColorAnnotator.py`. To test it, you can run `Client.py`. `Client.py` should be removed as soon as this is working nicely with the Java side of things.

Covers #15

I need to finish my statistics homework, afterwards I can integrate this with Lewis' PR.