### PR TITLE
Block Detection Annotator (blocked by pointing)

### DIFF
--- a/desc/BlockDetectionAnnotatorDescriptor.xml
+++ b/desc/BlockDetectionAnnotatorDescriptor.xml
@@ -17,25 +17,45 @@
           <supertypeName>uima.tcas.Annotation</supertypeName>
           <features>
             <featureDescription>
+              <name>id</name>
+              <description/>
+              <rangeTypeName>uima.cas.Double</rangeTypeName>
+            </featureDescription>
+            <featureDescription>
               <name>center_X</name>
               <description/>
-              <rangeTypeName>uima.cas.String</rangeTypeName>
+              <rangeTypeName>uima.cas.Double</rangeTypeName>
             </featureDescription>
             <featureDescription>
               <name>center_Y</name>
               <description/>
-              <rangeTypeName>uima.cas.String</rangeTypeName>
+              <rangeTypeName>uima.cas.Double</rangeTypeName>
             </featureDescription>
             <featureDescription>
               <name>depth</name>
               <description/>
-              <rangeTypeName>uima.cas.String</rangeTypeName>
+              <rangeTypeName>uima.cas.Double</rangeTypeName>
+            </featureDescription>
+            <featureDescription>
+            	<name>r_hue</name>
+            	<description></description>
+            	<rangeTypeName>uima.cas.Double</rangeTypeName>
+            </featureDescription>
+            <featureDescription>
+              <name>g_hue</name>
+              <description></description>
+              <rangeTypeName>uima.cas.Double</rangeTypeName>
+            </featureDescription>
+            <featureDescription>
+              <name>b_hue</name>
+              <description></description>
+              <rangeTypeName>uima.cas.Double</rangeTypeName>
             </featureDescription>
           </features>
         </typeDescription>
       </types>
     </typeSystemDescription>
-    <typePriorities/>
+    <typePriorities></typePriorities>
     <fsIndexCollection/>
     <capabilities>
       <capability>

--- a/desc/BlockDetectionAnnotatorDescriptor.xml
+++ b/desc/BlockDetectionAnnotatorDescriptor.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<analysisEngineDescription xmlns="http://uima.apache.org/resourceSpecifier">
+  <frameworkImplementation>org.apache.uima.java</frameworkImplementation>
+  <primitive>true</primitive>  <annotatorImplementationName>edu.rosehulman.aixprize.pipeline.annotators.BlockDetectionAnnotator</annotatorImplementationName>
+  <analysisEngineMetaData>
+    <name>BlockDetectionAnnotatorDescriptor</name>
+    <description/>
+    <version>1.0</version>
+    <vendor/>
+    <configurationParameters/>
+    <configurationParameterSettings/>
+    <typeSystemDescription>
+      <types>
+        <typeDescription>
+          <name>edu.rosehulman.aixprize.pipeline.types.Pointing</name>
+          <description/>
+          <supertypeName>uima.tcas.Annotation</supertypeName>
+          <features>
+            <featureDescription>
+              <name>confidence</name>
+              <description/>
+              <rangeTypeName>uima.cas.String</rangeTypeName>
+            </featureDescription>
+          </features>
+        </typeDescription>
+      </types>
+    </typeSystemDescription>
+    <typePriorities/>
+    <fsIndexCollection/>
+    <capabilities>
+      <capability>
+        <inputs/>
+        <outputs/>
+        <languagesSupported/>
+      </capability>
+    </capabilities>
+  <operationalProperties>
+      <modifiesCas>true</modifiesCas>
+      <multipleDeploymentAllowed>true</multipleDeploymentAllowed>
+      <outputsNewCASes>false</outputsNewCASes>
+    </operationalProperties>
+  </analysisEngineMetaData>
+  <resourceManagerConfiguration/>
+</analysisEngineDescription>

--- a/desc/BlockDetectionAnnotatorDescriptor.xml
+++ b/desc/BlockDetectionAnnotatorDescriptor.xml
@@ -12,12 +12,22 @@
     <typeSystemDescription>
       <types>
         <typeDescription>
-          <name>edu.rosehulman.aixprize.pipeline.types.Pointing</name>
+          <name>edu.rosehulman.aixprize.pipeline.types.DetectedBlock</name>
           <description/>
           <supertypeName>uima.tcas.Annotation</supertypeName>
           <features>
             <featureDescription>
-              <name>confidence</name>
+              <name>center_X</name>
+              <description/>
+              <rangeTypeName>uima.cas.String</rangeTypeName>
+            </featureDescription>
+            <featureDescription>
+              <name>center_Y</name>
+              <description/>
+              <rangeTypeName>uima.cas.String</rangeTypeName>
+            </featureDescription>
+            <featureDescription>
+              <name>depth</name>
               <description/>
               <rangeTypeName>uima.cas.String</rangeTypeName>
             </featureDescription>

--- a/desc/servers.json
+++ b/desc/servers.json
@@ -5,8 +5,13 @@
         "path": "/"
     },
     "edu.rosehulman.aixprize.pipeline.annotators.PointingAnnotator": {
-        "address": "127.0.0.1",
+        "address": "localhost",
         "port": 56814,
         "path": "/api/values"
+    },
+    "edu.rosehulman.aixprize.pipeline.annotators.BlockDetectionAnnotator": {
+        "address": "localhost",
+        "port": 56814,
+        "path": "/api/ObjectDetection"
     }
 }

--- a/src/main/java/edu/rosehulman/aixprize/pipeline/annotators/BlockDetectionAnnotator.java
+++ b/src/main/java/edu/rosehulman/aixprize/pipeline/annotators/BlockDetectionAnnotator.java
@@ -1,0 +1,7 @@
+package edu.rosehulman.aixprize.pipeline.annotators;
+
+import edu.rosehulman.aixprize.pipeline.http.HttpAnnotator;
+
+public class BlockDetectionAnnotator extends HttpAnnotator {
+
+}

--- a/src/main/java/edu/rosehulman/aixprize/pipeline/http/HttpAnnotator.java
+++ b/src/main/java/edu/rosehulman/aixprize/pipeline/http/HttpAnnotator.java
@@ -9,6 +9,7 @@ import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.*;
 import org.apache.http.params.BasicHttpParams;
@@ -45,8 +46,9 @@ public abstract class HttpAnnotator extends JCasAnnotator_ImplBase {
 //									   .setPath(configurationLoader.getPath(this.getClass()))
 //									   .build();
 			this.uri = "http://localhost" + ":" + configurationLoader.getPort(this.getClass())  + configurationLoader.getPath(this.getClass());
+//			this.uri = "https://requestbin.fullcontact.com/1f8s9dn1";
 			this.client = HttpClientBuilder.create().build();
-		} catch (NoConfigurationFound e) {
+		} catch (Exception e) {
 			e.printStackTrace();
 		}
 	}
@@ -71,7 +73,7 @@ public abstract class HttpAnnotator extends JCasAnnotator_ImplBase {
 	private HttpEntity encodeCas(JCas cas) throws IOException {
 		StringWriter serialized = new StringWriter();
 		JsonCasSerializer.jsonSerialize(cas.getCas(), serialized);
-		return new StringEntity(serialized.toString());
+		return new StringEntity(serialized.toString(), ContentType.APPLICATION_JSON);
 	}
 
 	private void receiveAnnotations(JCas cas, HttpResponse resp) throws IOException {

--- a/src/main/java/edu/rosehulman/aixprize/pipeline/types/DetectedBlock.java
+++ b/src/main/java/edu/rosehulman/aixprize/pipeline/types/DetectedBlock.java
@@ -1,0 +1,129 @@
+
+/* Apache UIMA v3 - First created by JCasGen Wed Dec 12 23:28:16 EST 2018 */
+
+package edu.rosehulman.aixprize.pipeline.types;
+
+import org.apache.uima.jcas.JCas;
+import org.apache.uima.jcas.JCasRegistry;
+import org.apache.uima.jcas.cas.TOP_Type;
+import org.apache.uima.jcas.tcas.Annotation;
+
+public class DetectedBlock extends Annotation {
+	/**
+	 * @generated
+	 * @ordered
+	 */
+	@SuppressWarnings("hiding")
+	public final static int typeIndexID = JCasRegistry.register(DetectedBlock.class);
+	/**
+	 * @generated
+	 * @ordered
+	 */
+	@SuppressWarnings("hiding")
+	public final static int type = typeIndexID;
+
+	/**
+	 * @generated
+	 * @return index of the type
+	 */
+	@Override
+	public int getTypeIndexID() {
+		return typeIndexID;
+	}
+
+	/**
+	 * Never called. Disable default constructor
+	 * 
+	 * @generated
+	 */
+	protected DetectedBlock() {
+		/* intentionally empty block */}
+
+	/**
+	 * Internal - constructor used by generator
+	 * 
+	 * @generated
+	 * @param casImpl
+	 *            the CAS this Feature Structure belongs to
+	 * @param type
+	 *            the type of this Feature Structure
+	 */
+	public DetectedBlock(int addr, TOP_Type type) {
+		super(addr, type);
+		readObject();
+	}
+
+	/**
+	 * @generated
+	 * @param jcas
+	 *            JCas to which this Feature Structure belongs
+	 */
+	public DetectedBlock(JCas jcas) {
+		super(jcas);
+		readObject();
+	}
+
+	/**
+	 * @generated
+	 * @param jcas
+	 *            JCas to which this Feature Structure belongs
+	 * @param begin
+	 *            offset to the begin spot in the SofA
+	 * @param end
+	 *            offset to the end spot in the SofA
+	 */
+	public DetectedBlock(JCas jcas, int begin, int end) {
+		super(jcas);
+		setBegin(begin);
+		setEnd(end);
+		readObject();
+	}
+
+	/**
+	 * <!-- begin-user-doc --> Write your own initialization here <!-- end-user-doc
+	 * -->
+	 *
+	 * @generated modifiable
+	 */
+	private void readObject() {
+		/* default - does nothing empty block */}
+
+	// *--------------*
+	// * Feature: confidence
+
+	public String getCenter_X(int addr) {
+		if (DetectedBlock_Type.featOkTst && ((DetectedBlock_Type) jcasType).casFeat_center_X == null)
+			jcasType.jcas.throwFeatMissing("center_X", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
+		return jcasType.ll_cas.ll_getStringValue(addr, ((DetectedBlock_Type) jcasType).casFeatCode_center_X);
+	}
+
+	public void setCenter_X(int addr, String v) {
+		if (DetectedBlock_Type.featOkTst && ((DetectedBlock_Type) jcasType).casFeat_center_X == null)
+			jcasType.jcas.throwFeatMissing("center_X", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
+		jcasType.ll_cas.ll_setStringValue(addr, ((DetectedBlock_Type) jcasType).casFeatCode_center_X, v);
+	}
+
+	public String getCenter_Y(int addr) {
+		if (DetectedBlock_Type.featOkTst && ((DetectedBlock_Type) jcasType).casFeat_center_Y == null)
+			jcasType.jcas.throwFeatMissing("center_Y", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
+		return jcasType.ll_cas.ll_getStringValue(addr, ((DetectedBlock_Type) jcasType).casFeatCode_center_Y);
+	}
+
+	public void setCenter_Y(int addr, String v) {
+		if (DetectedBlock_Type.featOkTst && ((DetectedBlock_Type) jcasType).casFeat_center_Y == null)
+			jcasType.jcas.throwFeatMissing("center_Y", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
+		jcasType.ll_cas.ll_setStringValue(addr, ((DetectedBlock_Type) jcasType).casFeatCode_center_Y, v);
+	}
+
+	public String getDepth(int addr) {
+		if (DetectedBlock_Type.featOkTst && ((DetectedBlock_Type) jcasType).casFeat_depth == null)
+			jcasType.jcas.throwFeatMissing("depth", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
+		return jcasType.ll_cas.ll_getStringValue(addr, ((DetectedBlock_Type) jcasType).casFeatCode_depth);
+	}
+
+	public void setDepth(int addr, String v) {
+		if (DetectedBlock_Type.featOkTst && ((DetectedBlock_Type) jcasType).casFeat_depth == null)
+			jcasType.jcas.throwFeatMissing("depth", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
+		jcasType.ll_cas.ll_setStringValue(addr, ((DetectedBlock_Type) jcasType).casFeatCode_depth, v);
+	}
+}

--- a/src/main/java/edu/rosehulman/aixprize/pipeline/types/DetectedBlock.java
+++ b/src/main/java/edu/rosehulman/aixprize/pipeline/types/DetectedBlock.java
@@ -91,39 +91,88 @@ public class DetectedBlock extends Annotation {
 	// *--------------*
 	// * Feature: confidence
 
-	public String getCenter_X(int addr) {
+	public int getId(int addr) {
+		if (DetectedBlock_Type.featOkTst && ((DetectedBlock_Type) jcasType).casFeat_id == null)
+			jcasType.jcas.throwFeatMissing("id", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
+		return jcasType.ll_cas.ll_getIntValue(addr, ((DetectedBlock_Type) jcasType).casFeatCode_id);
+	}
+
+	public void setId(int addr, int v) {
+		if (DetectedBlock_Type.featOkTst && ((DetectedBlock_Type) jcasType).casFeat_id == null)
+			jcasType.jcas.throwFeatMissing("id", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
+		jcasType.ll_cas.ll_setIntValue(addr, ((DetectedBlock_Type) jcasType).casFeatCode_id, v);
+	}
+	
+	public int getCenter_X(int addr) {
 		if (DetectedBlock_Type.featOkTst && ((DetectedBlock_Type) jcasType).casFeat_center_X == null)
 			jcasType.jcas.throwFeatMissing("center_X", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
-		return jcasType.ll_cas.ll_getStringValue(addr, ((DetectedBlock_Type) jcasType).casFeatCode_center_X);
+		return jcasType.ll_cas.ll_getIntValue(addr, ((DetectedBlock_Type) jcasType).casFeatCode_center_X);
 	}
 
-	public void setCenter_X(int addr, String v) {
+	public void setCenter_X(int addr, int v) {
 		if (DetectedBlock_Type.featOkTst && ((DetectedBlock_Type) jcasType).casFeat_center_X == null)
 			jcasType.jcas.throwFeatMissing("center_X", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
-		jcasType.ll_cas.ll_setStringValue(addr, ((DetectedBlock_Type) jcasType).casFeatCode_center_X, v);
+		jcasType.ll_cas.ll_setIntValue(addr, ((DetectedBlock_Type) jcasType).casFeatCode_center_X, v);
 	}
-
-	public String getCenter_Y(int addr) {
+	
+	public int getCenter_Y(int addr) {
 		if (DetectedBlock_Type.featOkTst && ((DetectedBlock_Type) jcasType).casFeat_center_Y == null)
 			jcasType.jcas.throwFeatMissing("center_Y", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
-		return jcasType.ll_cas.ll_getStringValue(addr, ((DetectedBlock_Type) jcasType).casFeatCode_center_Y);
+		return jcasType.ll_cas.ll_getIntValue(addr, ((DetectedBlock_Type) jcasType).casFeatCode_center_Y);
 	}
 
-	public void setCenter_Y(int addr, String v) {
+	public void setCenter_Y(int addr, int v) {
 		if (DetectedBlock_Type.featOkTst && ((DetectedBlock_Type) jcasType).casFeat_center_Y == null)
 			jcasType.jcas.throwFeatMissing("center_Y", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
-		jcasType.ll_cas.ll_setStringValue(addr, ((DetectedBlock_Type) jcasType).casFeatCode_center_Y, v);
+		jcasType.ll_cas.ll_setIntValue(addr, ((DetectedBlock_Type) jcasType).casFeatCode_center_Y, v);
 	}
-
-	public String getDepth(int addr) {
+	
+	public int getDepth(int addr) {
 		if (DetectedBlock_Type.featOkTst && ((DetectedBlock_Type) jcasType).casFeat_depth == null)
 			jcasType.jcas.throwFeatMissing("depth", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
-		return jcasType.ll_cas.ll_getStringValue(addr, ((DetectedBlock_Type) jcasType).casFeatCode_depth);
+		return jcasType.ll_cas.ll_getIntValue(addr, ((DetectedBlock_Type) jcasType).casFeatCode_depth);
 	}
 
-	public void setDepth(int addr, String v) {
+	public void setDepth(int addr, int v) {
 		if (DetectedBlock_Type.featOkTst && ((DetectedBlock_Type) jcasType).casFeat_depth == null)
 			jcasType.jcas.throwFeatMissing("depth", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
-		jcasType.ll_cas.ll_setStringValue(addr, ((DetectedBlock_Type) jcasType).casFeatCode_depth, v);
+		jcasType.ll_cas.ll_setIntValue(addr, ((DetectedBlock_Type) jcasType).casFeatCode_depth, v);
 	}
+	
+	public int getR_Hue(int addr) {
+		if (DetectedBlock_Type.featOkTst && ((DetectedBlock_Type) jcasType).casFeat_r_hue == null)
+			jcasType.jcas.throwFeatMissing("r_hue", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
+		return jcasType.ll_cas.ll_getIntValue(addr, ((DetectedBlock_Type) jcasType).casFeatCode_r_hue);
+	}
+
+	public void setR_Hue(int addr, int v) {
+		if (DetectedBlock_Type.featOkTst && ((DetectedBlock_Type) jcasType).casFeat_r_hue == null)
+			jcasType.jcas.throwFeatMissing("r_hue", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
+		jcasType.ll_cas.ll_setIntValue(addr, ((DetectedBlock_Type) jcasType).casFeatCode_r_hue, v);
+	}
+	
+	public int getG_Hue(int addr) {
+		if (DetectedBlock_Type.featOkTst && ((DetectedBlock_Type) jcasType).casFeat_g_hue == null)
+			jcasType.jcas.throwFeatMissing("g_hue", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
+		return jcasType.ll_cas.ll_getIntValue(addr, ((DetectedBlock_Type) jcasType).casFeatCode_g_hue);
+	}
+
+	public void setG_Hue(int addr, int v) {
+		if (DetectedBlock_Type.featOkTst && ((DetectedBlock_Type) jcasType).casFeat_g_hue == null)
+			jcasType.jcas.throwFeatMissing("g_hue", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
+		jcasType.ll_cas.ll_setIntValue(addr, ((DetectedBlock_Type) jcasType).casFeatCode_g_hue, v);
+	}
+	
+	public int getB_Hue(int addr) {
+		if (DetectedBlock_Type.featOkTst && ((DetectedBlock_Type) jcasType).casFeat_b_hue == null)
+			jcasType.jcas.throwFeatMissing("b_hue", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
+		return jcasType.ll_cas.ll_getIntValue(addr, ((DetectedBlock_Type) jcasType).casFeatCode_b_hue);
+	}
+
+	public void setB_Hue(int addr, int v) {
+		if (DetectedBlock_Type.featOkTst && ((DetectedBlock_Type) jcasType).casFeat_b_hue == null)
+			jcasType.jcas.throwFeatMissing("b_hue", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
+		jcasType.ll_cas.ll_setIntValue(addr, ((DetectedBlock_Type) jcasType).casFeatCode_b_hue, v);
+	}
+	
 }

--- a/src/main/java/edu/rosehulman/aixprize/pipeline/types/DetectedBlock_Type.java
+++ b/src/main/java/edu/rosehulman/aixprize/pipeline/types/DetectedBlock_Type.java
@@ -28,55 +28,99 @@ public class DetectedBlock_Type extends Annotation_Type {
 	
 	final Feature casFeat_depth;
 	final int casFeatCode_depth;
+	
+	final Feature casFeat_r_hue;
+	final int casFeatCode_r_hue;
+	
+	final Feature casFeat_g_hue;
+	final int casFeatCode_g_hue;
+	
+	final Feature casFeat_b_hue;
+	final int casFeatCode_b_hue;
 
-	public int getId(int addr) {
+	public double getId(int addr) {
 		if (featOkTst && casFeat_id == null)
 			jcas.throwFeatMissing("id", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
-		return ll_cas.ll_getIntValue(addr, casFeatCode_id);
+		return ll_cas.ll_getDoubleValue(addr, casFeatCode_id);
 	}
 
-	public void setId(int addr, int v) {
+	public void setId(int addr, double v) {
 		if (featOkTst && casFeat_id == null)
 			jcas.throwFeatMissing("id", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
-		ll_cas.ll_setIntValue(addr, casFeatCode_id, v);
+		ll_cas.ll_setDoubleValue(addr, casFeatCode_id, v);
 	}
 	
-	public int getCenter_X(int addr) {
+	public double getCenter_X(int addr) {
 		if (featOkTst && casFeat_center_X == null)
 			jcas.throwFeatMissing("center_X", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
-		return ll_cas.ll_getIntValue(addr, casFeatCode_center_X);
+		return ll_cas.ll_getDoubleValue(addr, casFeatCode_center_X);
 	}
 
-	public void setCenter_X(int addr, int v) {
+	public void setCenter_X(int addr, double v) {
 		if (featOkTst && casFeat_center_X == null)
 			jcas.throwFeatMissing("center_X", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
-		ll_cas.ll_setIntValue(addr, casFeatCode_center_X, v);
+		ll_cas.ll_setDoubleValue(addr, casFeatCode_center_X, v);
 	}
 	
-	public int getCenter_Y(int addr) {
+	public double getCenter_Y(int addr) {
 		if (featOkTst && casFeat_center_Y == null)
 			jcas.throwFeatMissing("center_Y", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
-		return ll_cas.ll_getIntValue(addr, casFeatCode_center_Y);
+		return ll_cas.ll_getDoubleValue(addr, casFeatCode_center_Y);
 	}
 
-	public void setCenter_Y(int addr, int v) {
+	public void setCenter_Y(int addr, double v) {
 		if (featOkTst && casFeat_center_Y == null)
 			jcas.throwFeatMissing("center_Y", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
-		ll_cas.ll_setIntValue(addr, casFeatCode_center_Y, v);
+		ll_cas.ll_setDoubleValue(addr, casFeatCode_center_Y, v);
 	}
 	
-	public int getDepth(int addr) {
+	public double getDepth(int addr) {
 		if (featOkTst && casFeat_depth == null)
 			jcas.throwFeatMissing("depth", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
-		return ll_cas.ll_getIntValue(addr, casFeatCode_depth);
+		return ll_cas.ll_getDoubleValue(addr, casFeatCode_depth);
 	}
 
-	public void setDepth(int addr, int v) {
+	public void setDepth(int addr, double v) {
 		if (featOkTst && casFeat_depth == null)
 			jcas.throwFeatMissing("depth", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
-		ll_cas.ll_setIntValue(addr, casFeatCode_depth, v);
+		ll_cas.ll_setDoubleValue(addr, casFeatCode_depth, v);
+	}
+	
+	public double getR_Hue(int addr) {
+		if (featOkTst && casFeat_r_hue == null)
+			jcas.throwFeatMissing("r_hue", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
+		return ll_cas.ll_getDoubleValue(addr, casFeatCode_r_hue);
 	}
 
+	public void setR_Hue(int addr, double v) {
+		if (featOkTst && casFeat_r_hue == null)
+			jcas.throwFeatMissing("r_hue", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
+		ll_cas.ll_setDoubleValue(addr, casFeatCode_r_hue, v);
+	}
+	
+	public double getG_Hue(int addr) {
+		if (featOkTst && casFeat_g_hue == null)
+			jcas.throwFeatMissing("g_hue", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
+		return ll_cas.ll_getDoubleValue(addr, casFeatCode_g_hue);
+	}
+
+	public void setG_Hue(int addr, double v) {
+		if (featOkTst && casFeat_g_hue == null)
+			jcas.throwFeatMissing("g_hue", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
+		ll_cas.ll_setDoubleValue(addr, casFeatCode_g_hue, v);
+	}
+	
+	public double getB_Hue(int addr) {
+		if (featOkTst && casFeat_b_hue == null)
+			jcas.throwFeatMissing("b_hue", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
+		return ll_cas.ll_getDoubleValue(addr, casFeatCode_b_hue);
+	}
+
+	public void setB_Hue(int addr, double v) {
+		if (featOkTst && casFeat_b_hue == null)
+			jcas.throwFeatMissing("b_hue", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
+		ll_cas.ll_setDoubleValue(addr, casFeatCode_b_hue, v);
+	}
 
 	/**
 	 * initialize variables to correspond with Cas Type and Features
@@ -91,20 +135,32 @@ public class DetectedBlock_Type extends Annotation_Type {
 		super(jcas, casType);
 		casImpl.getFSClassRegistry().addGeneratorForType((TypeImpl) this.casType, getFSGenerator());
 
-		casFeat_id = jcas.getRequiredFeatureDE(casType, "id", "uima.cas.int", featOkTst);
+		casFeat_id = jcas.getRequiredFeatureDE(casType, "id", "uima.cas.Double", featOkTst);
 		casFeatCode_id = (null == casFeat_id) ? JCas.INVALID_FEATURE_CODE
 				: ((FeatureImpl) casFeat_id).getCode();
 		
-		casFeat_center_X = jcas.getRequiredFeatureDE(casType, "center_X", "uima.cas.int", featOkTst);
+		casFeat_center_X = jcas.getRequiredFeatureDE(casType, "center_X", "uima.cas.Double", featOkTst);
 		casFeatCode_center_X = (null == casFeat_center_X) ? JCas.INVALID_FEATURE_CODE
 				: ((FeatureImpl) casFeat_center_X).getCode();
 		
-		casFeat_center_Y = jcas.getRequiredFeatureDE(casType, "center_Y", "uima.cas.int", featOkTst);
+		casFeat_center_Y = jcas.getRequiredFeatureDE(casType, "center_Y", "uima.cas.Double", featOkTst);
 		casFeatCode_center_Y = (null == casFeat_center_Y) ? JCas.INVALID_FEATURE_CODE
 				: ((FeatureImpl) casFeat_center_Y).getCode();
 		
-		casFeat_depth = jcas.getRequiredFeatureDE(casType, "depth", "uima.cas.int", featOkTst);
+		casFeat_depth = jcas.getRequiredFeatureDE(casType, "depth", "uima.cas.Double", featOkTst);
 		casFeatCode_depth = (null == casFeat_depth) ? JCas.INVALID_FEATURE_CODE
 				: ((FeatureImpl) casFeat_depth).getCode();
+		
+		casFeat_r_hue = jcas.getRequiredFeatureDE(casType, "r_hue", "uima.cas.Double", featOkTst);
+		casFeatCode_r_hue = (null == casFeat_r_hue) ? JCas.INVALID_FEATURE_CODE
+				: ((FeatureImpl) casFeat_r_hue).getCode();
+		
+		casFeat_g_hue = jcas.getRequiredFeatureDE(casType, "g_hue", "uima.cas.Double", featOkTst);
+		casFeatCode_g_hue = (null == casFeat_g_hue) ? JCas.INVALID_FEATURE_CODE
+				: ((FeatureImpl) casFeat_g_hue).getCode();
+		
+		casFeat_b_hue = jcas.getRequiredFeatureDE(casType, "b_hue", "uima.cas.Double", featOkTst);
+		casFeatCode_b_hue = (null == casFeat_b_hue) ? JCas.INVALID_FEATURE_CODE
+				: ((FeatureImpl) casFeat_b_hue).getCode();
 	}
 }

--- a/src/main/java/edu/rosehulman/aixprize/pipeline/types/DetectedBlock_Type.java
+++ b/src/main/java/edu/rosehulman/aixprize/pipeline/types/DetectedBlock_Type.java
@@ -1,0 +1,91 @@
+package edu.rosehulman.aixprize.pipeline.types;
+
+import org.apache.uima.jcas.JCas;
+import org.apache.uima.jcas.JCasRegistry;
+import org.apache.uima.cas.impl.TypeImpl;
+import org.apache.uima.cas.Type;
+import org.apache.uima.cas.impl.FeatureImpl;
+import org.apache.uima.cas.Feature;
+import org.apache.uima.jcas.tcas.Annotation_Type;
+
+public class DetectedBlock_Type extends Annotation_Type {
+
+	@SuppressWarnings("hiding")
+	public final static int typeIndexID = Color.typeIndexID;
+
+	@SuppressWarnings("hiding")
+	public final static boolean featOkTst = JCasRegistry
+			.getFeatOkTst("edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
+
+	final Feature casFeat_center_X;
+	final int casFeatCode_center_X;
+	
+	final Feature casFeat_center_Y;
+	final int casFeatCode_center_Y;
+	
+	final Feature casFeat_depth;
+	final int casFeatCode_depth;
+
+	public String getCenter_X(int addr) {
+		if (featOkTst && casFeat_center_X == null)
+			jcas.throwFeatMissing("center_X", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
+		return ll_cas.ll_getStringValue(addr, casFeatCode_center_X);
+	}
+
+	public void setCenter_X(int addr, String v) {
+		if (featOkTst && casFeat_center_X == null)
+			jcas.throwFeatMissing("center_X", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
+		ll_cas.ll_setStringValue(addr, casFeatCode_center_X, v);
+	}
+	
+	public String getCenter_Y(int addr) {
+		if (featOkTst && casFeat_center_Y == null)
+			jcas.throwFeatMissing("center_Y", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
+		return ll_cas.ll_getStringValue(addr, casFeatCode_center_Y);
+	}
+
+	public void setCenter_Y(int addr, String v) {
+		if (featOkTst && casFeat_center_Y == null)
+			jcas.throwFeatMissing("center_Y", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
+		ll_cas.ll_setStringValue(addr, casFeatCode_center_Y, v);
+	}
+	
+	public String getDepth(int addr) {
+		if (featOkTst && casFeat_depth == null)
+			jcas.throwFeatMissing("depth", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
+		return ll_cas.ll_getStringValue(addr, casFeatCode_depth);
+	}
+
+	public void setDepth(int addr, String v) {
+		if (featOkTst && casFeat_depth == null)
+			jcas.throwFeatMissing("depth", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
+		ll_cas.ll_setStringValue(addr, casFeatCode_depth, v);
+	}
+
+
+	/**
+	 * initialize variables to correspond with Cas Type and Features
+	 * 
+	 * @generated
+	 * @param jcas
+	 *            JCas
+	 * @param casType
+	 *            Type
+	 */
+	public DetectedBlock_Type(JCas jcas, Type casType) {
+		super(jcas, casType);
+		casImpl.getFSClassRegistry().addGeneratorForType((TypeImpl) this.casType, getFSGenerator());
+
+		casFeat_center_X = jcas.getRequiredFeatureDE(casType, "center_X", "uima.cas.String", featOkTst);
+		casFeatCode_center_X = (null == casFeat_center_X) ? JCas.INVALID_FEATURE_CODE
+				: ((FeatureImpl) casFeat_center_X).getCode();
+		
+		casFeat_center_Y = jcas.getRequiredFeatureDE(casType, "center_Y", "uima.cas.String", featOkTst);
+		casFeatCode_center_Y = (null == casFeat_center_Y) ? JCas.INVALID_FEATURE_CODE
+				: ((FeatureImpl) casFeat_center_Y).getCode();
+		
+		casFeat_depth = jcas.getRequiredFeatureDE(casType, "depth", "uima.cas.String", featOkTst);
+		casFeatCode_depth = (null == casFeat_depth) ? JCas.INVALID_FEATURE_CODE
+				: ((FeatureImpl) casFeat_depth).getCode();
+	}
+}

--- a/src/main/java/edu/rosehulman/aixprize/pipeline/types/DetectedBlock_Type.java
+++ b/src/main/java/edu/rosehulman/aixprize/pipeline/types/DetectedBlock_Type.java
@@ -11,7 +11,7 @@ import org.apache.uima.jcas.tcas.Annotation_Type;
 public class DetectedBlock_Type extends Annotation_Type {
 
 	@SuppressWarnings("hiding")
-	public final static int typeIndexID = Color.typeIndexID;
+	public final static int typeIndexID = DetectedBlock.typeIndexID;
 
 	@SuppressWarnings("hiding")
 	public final static boolean featOkTst = JCasRegistry

--- a/src/main/java/edu/rosehulman/aixprize/pipeline/types/DetectedBlock_Type.java
+++ b/src/main/java/edu/rosehulman/aixprize/pipeline/types/DetectedBlock_Type.java
@@ -17,6 +17,9 @@ public class DetectedBlock_Type extends Annotation_Type {
 	public final static boolean featOkTst = JCasRegistry
 			.getFeatOkTst("edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
 
+	final Feature casFeat_id;
+	final int casFeatCode_id;
+	
 	final Feature casFeat_center_X;
 	final int casFeatCode_center_X;
 	
@@ -26,40 +29,52 @@ public class DetectedBlock_Type extends Annotation_Type {
 	final Feature casFeat_depth;
 	final int casFeatCode_depth;
 
-	public String getCenter_X(int addr) {
-		if (featOkTst && casFeat_center_X == null)
-			jcas.throwFeatMissing("center_X", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
-		return ll_cas.ll_getStringValue(addr, casFeatCode_center_X);
+	public int getId(int addr) {
+		if (featOkTst && casFeat_id == null)
+			jcas.throwFeatMissing("id", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
+		return ll_cas.ll_getIntValue(addr, casFeatCode_id);
 	}
 
-	public void setCenter_X(int addr, String v) {
-		if (featOkTst && casFeat_center_X == null)
-			jcas.throwFeatMissing("center_X", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
-		ll_cas.ll_setStringValue(addr, casFeatCode_center_X, v);
+	public void setId(int addr, int v) {
+		if (featOkTst && casFeat_id == null)
+			jcas.throwFeatMissing("id", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
+		ll_cas.ll_setIntValue(addr, casFeatCode_id, v);
 	}
 	
-	public String getCenter_Y(int addr) {
-		if (featOkTst && casFeat_center_Y == null)
-			jcas.throwFeatMissing("center_Y", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
-		return ll_cas.ll_getStringValue(addr, casFeatCode_center_Y);
+	public int getCenter_X(int addr) {
+		if (featOkTst && casFeat_center_X == null)
+			jcas.throwFeatMissing("center_X", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
+		return ll_cas.ll_getIntValue(addr, casFeatCode_center_X);
 	}
 
-	public void setCenter_Y(int addr, String v) {
-		if (featOkTst && casFeat_center_Y == null)
-			jcas.throwFeatMissing("center_Y", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
-		ll_cas.ll_setStringValue(addr, casFeatCode_center_Y, v);
+	public void setCenter_X(int addr, int v) {
+		if (featOkTst && casFeat_center_X == null)
+			jcas.throwFeatMissing("center_X", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
+		ll_cas.ll_setIntValue(addr, casFeatCode_center_X, v);
 	}
 	
-	public String getDepth(int addr) {
-		if (featOkTst && casFeat_depth == null)
-			jcas.throwFeatMissing("depth", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
-		return ll_cas.ll_getStringValue(addr, casFeatCode_depth);
+	public int getCenter_Y(int addr) {
+		if (featOkTst && casFeat_center_Y == null)
+			jcas.throwFeatMissing("center_Y", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
+		return ll_cas.ll_getIntValue(addr, casFeatCode_center_Y);
 	}
 
-	public void setDepth(int addr, String v) {
+	public void setCenter_Y(int addr, int v) {
+		if (featOkTst && casFeat_center_Y == null)
+			jcas.throwFeatMissing("center_Y", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
+		ll_cas.ll_setIntValue(addr, casFeatCode_center_Y, v);
+	}
+	
+	public int getDepth(int addr) {
 		if (featOkTst && casFeat_depth == null)
 			jcas.throwFeatMissing("depth", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
-		ll_cas.ll_setStringValue(addr, casFeatCode_depth, v);
+		return ll_cas.ll_getIntValue(addr, casFeatCode_depth);
+	}
+
+	public void setDepth(int addr, int v) {
+		if (featOkTst && casFeat_depth == null)
+			jcas.throwFeatMissing("depth", "edu.rosehulman.aixprize.pipeline.types.DetectedBlock");
+		ll_cas.ll_setIntValue(addr, casFeatCode_depth, v);
 	}
 
 
@@ -76,15 +91,19 @@ public class DetectedBlock_Type extends Annotation_Type {
 		super(jcas, casType);
 		casImpl.getFSClassRegistry().addGeneratorForType((TypeImpl) this.casType, getFSGenerator());
 
-		casFeat_center_X = jcas.getRequiredFeatureDE(casType, "center_X", "uima.cas.String", featOkTst);
+		casFeat_id = jcas.getRequiredFeatureDE(casType, "id", "uima.cas.int", featOkTst);
+		casFeatCode_id = (null == casFeat_id) ? JCas.INVALID_FEATURE_CODE
+				: ((FeatureImpl) casFeat_id).getCode();
+		
+		casFeat_center_X = jcas.getRequiredFeatureDE(casType, "center_X", "uima.cas.int", featOkTst);
 		casFeatCode_center_X = (null == casFeat_center_X) ? JCas.INVALID_FEATURE_CODE
 				: ((FeatureImpl) casFeat_center_X).getCode();
 		
-		casFeat_center_Y = jcas.getRequiredFeatureDE(casType, "center_Y", "uima.cas.String", featOkTst);
+		casFeat_center_Y = jcas.getRequiredFeatureDE(casType, "center_Y", "uima.cas.int", featOkTst);
 		casFeatCode_center_Y = (null == casFeat_center_Y) ? JCas.INVALID_FEATURE_CODE
 				: ((FeatureImpl) casFeat_center_Y).getCode();
 		
-		casFeat_depth = jcas.getRequiredFeatureDE(casType, "depth", "uima.cas.String", featOkTst);
+		casFeat_depth = jcas.getRequiredFeatureDE(casType, "depth", "uima.cas.int", featOkTst);
 		casFeatCode_depth = (null == casFeat_depth) ? JCas.INVALID_FEATURE_CODE
 				: ((FeatureImpl) casFeat_depth).getCode();
 	}


### PR DESCRIPTION
This annotator is the follow-up to the pointing annotator. It receives the input from our pre-processing step of obtaining block details. These details include centers, associated depths, and RGB colors near the center. Adding these changes required creating a datatype that accepts these values from our block detection service and adding the corresponding `servers.json` file entry to access this block detection service.