### PR TITLE
Text Processing and Feedback

### DIFF
--- a/desc/AggregateConfidenceAnnotatorDescriptor.xml
+++ b/desc/AggregateConfidenceAnnotatorDescriptor.xml
@@ -26,6 +26,16 @@
               <description/>
               <rangeTypeName>uima.cas.Double</rangeTypeName>
             </featureDescription>
+            <featureDescription>
+              <name>normPointingConf</name>
+              <description/>
+              <rangeTypeName>uima.cas.Double</rangeTypeName>
+            </featureDescription>
+            <featureDescription>
+              <name>normTextConf</name>
+              <description/>
+              <rangeTypeName>uima.cas.Double</rangeTypeName>
+            </featureDescription>
           </features>
         </typeDescription>
       </types>

--- a/desc/CompoundAnnotatorDescriptor.xml
+++ b/desc/CompoundAnnotatorDescriptor.xml
@@ -21,6 +21,9 @@
     <delegateAnalysisEngine key="OutputAnnotatorDescriptor">
       <import location="/Users/duessel/Documents/Class/Senior Project/rhit-xprize-pipeline/desc/OutputAnnotatorDescriptor.xml"/>
     </delegateAnalysisEngine>
+    <delegateAnalysisEngine key="FeedbackAnnotatorDescriptor">
+      <import location="/Users/duessel/Documents/Class/Senior Project/rhit-xprize-pipeline/desc/FeedbackAnnotatorDescriptor.xml"/>
+    </delegateAnalysisEngine>
   </delegateAnalysisEngineSpecifiers>
   <analysisEngineMetaData>
     <name>CompoundAnnotator</name>
@@ -37,6 +40,7 @@
         <node>TextConfidenceAnnotatorDescriptor</node>
         <node>AggregateConfidenceAnnotatorDescriptor</node>
         <node>OutputAnnotatorDescriptor</node>
+        <node>FeedbackAnnotatorDescriptor</node>
       </fixedFlow>
     </flowConstraints>
     <fsIndexCollection/>

--- a/desc/FeedbackAnnotatorDescriptor.xml
+++ b/desc/FeedbackAnnotatorDescriptor.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <analysisEngineDescription xmlns="http://uima.apache.org/resourceSpecifier">
   <frameworkImplementation>org.apache.uima.java</frameworkImplementation>
-  <primitive>true</primitive>  <annotatorImplementationName>edu.rosehulman.aixprize.pipeline.annotators.OutputAnnotator</annotatorImplementationName>
+  <primitive>true</primitive>  <annotatorImplementationName>edu.rosehulman.aixprize.pipeline.annotators.FeedbackAnnotator</annotatorImplementationName>
   <analysisEngineMetaData>
-    <name>OutputAnnotatorDescriptor</name>
+    <name>FeedbackAnnotatorDescriptor</name>
     <description/>
     <version>1.0</version>
     <vendor/>
@@ -12,19 +12,14 @@
     <typeSystemDescription>
       <types>
         <typeDescription>
-          <name>edu.rosehulman.aixprize.pipeline.types.FilteredBlock</name>
+          <name>edu.rosehulman.aixprize.pipeline.types.Feedback</name>
           <description/>
           <supertypeName>uima.tcas.Annotation</supertypeName>
           <features>
             <featureDescription>
-              <name>id</name>
+              <name>feedbackMsg</name>
               <description/>
-              <rangeTypeName>uima.cas.Double</rangeTypeName>
-            </featureDescription>
-            <featureDescription>
-              <name>isSelectedBlock</name>
-              <description/>
-              <rangeTypeName>uima.cas.Double</rangeTypeName>
+              <rangeTypeName>uima.cas.String</rangeTypeName>
             </featureDescription>
           </features>
         </typeDescription>

--- a/desc/servers.json
+++ b/desc/servers.json
@@ -28,5 +28,10 @@
         "address": "localhost",
         "port": 3000,
         "path": "/AggregateConfidence"
+    },
+    "edu.rosehulman.aixprize.pipeline.annotators.FeedbackAnnotator": {
+        "address": "localhost",
+        "port": 3000,
+        "path": "/Feedback"
     }
 }

--- a/src/main/java/edu/rosehulman/aixprize/pipeline/annotators/FeedbackAnnotator.java
+++ b/src/main/java/edu/rosehulman/aixprize/pipeline/annotators/FeedbackAnnotator.java
@@ -1,0 +1,7 @@
+package edu.rosehulman.aixprize.pipeline.annotators;
+
+import edu.rosehulman.aixprize.pipeline.http.HttpAnnotator;
+
+public class FeedbackAnnotator extends HttpAnnotator {
+
+}

--- a/src/main/java/edu/rosehulman/aixprize/pipeline/core/Controller.java
+++ b/src/main/java/edu/rosehulman/aixprize/pipeline/core/Controller.java
@@ -28,6 +28,7 @@ public class Controller {
 			XMLInputSource xmlInput = new XMLInputSource(compoundAnnotatorDescriptor);
 			ResourceSpecifier specifier = UIMAFramework.getXMLParser().parseResourceSpecifier(xmlInput);
 
+			Thread.sleep(4000);
 			AnalysisEngine analysisEngine = UIMAFramework.produceAnalysisEngine(specifier);
 			JCas cas = analysisEngine.newJCas();
 

--- a/src/main/java/edu/rosehulman/aixprize/pipeline/http/HttpAnnotator.java
+++ b/src/main/java/edu/rosehulman/aixprize/pipeline/http/HttpAnnotator.java
@@ -40,13 +40,11 @@ public abstract class HttpAnnotator extends JCasAnnotator_ImplBase {
 		HttpConfigurationLoader configurationLoader = HttpConfigurationLoader.getInstance();
 
 		try {
-			//this.uri = new URIBuilder().setHost(configurationLoader.getAddress(this.getClass()))
-//									   .setScheme("http")
-//									   .setPort(configurationLoader.getPort(this.getClass()))
-//									   .setPath(configurationLoader.getPath(this.getClass()))
-//									   .build();
-			this.uri = "http://localhost" + ":" + configurationLoader.getPort(this.getClass())  + configurationLoader.getPath(this.getClass());
-//			this.uri = "https://requestbin.fullcontact.com/1f8s9dn1";
+			this.uri = new URIBuilder().setHost(configurationLoader.getAddress(this.getClass()))
+									   .setScheme("http")
+									   .setPort(configurationLoader.getPort(this.getClass()))
+									   .setPath(configurationLoader.getPath(this.getClass()))
+									   .build().toString();
 			this.client = HttpClientBuilder.create().build();
 		} catch (Exception e) {
 			e.printStackTrace();
@@ -60,9 +58,6 @@ public abstract class HttpAnnotator extends JCasAnnotator_ImplBase {
 		}
 		
 		System.out.println(uri.toString());
-
-		System.out.println(uri.toString());
-
 		try {
 			RequestBuilder requestBuilder = RequestBuilder.post(uri);
 			requestBuilder.setEntity(encodeCas(cas));

--- a/src/main/java/edu/rosehulman/aixprize/pipeline/types/AggregateConfidence.java
+++ b/src/main/java/edu/rosehulman/aixprize/pipeline/types/AggregateConfidence.java
@@ -108,6 +108,18 @@ public class AggregateConfidence extends Annotation {
 		return jcasType.ll_cas.ll_getDoubleValue(addr, ((AggregateConfidence_Type) jcasType).casFeatCode_confidence);
 	}
 	
+	public double getNormPointingConfidence() {
+		if (AggregateConfidence_Type.featOkTst && ((AggregateConfidence_Type) jcasType).casFeat_normPointingConf == null)
+			jcasType.jcas.throwFeatMissing("normPointingConf", "edu.rosehulman.aixprize.pipeline.types.AggregateConfidence");
+		return jcasType.ll_cas.ll_getDoubleValue(addr, ((AggregateConfidence_Type) jcasType).casFeatCode_normPointingConf);
+	}
+	
+	public double getNormTextConfidence() {
+		if (AggregateConfidence_Type.featOkTst && ((AggregateConfidence_Type) jcasType).casFeat_normTextConf == null)
+			jcasType.jcas.throwFeatMissing("normTextConf", "edu.rosehulman.aixprize.pipeline.types.AggregateConfidence");
+		return jcasType.ll_cas.ll_getDoubleValue(addr, ((AggregateConfidence_Type) jcasType).casFeatCode_normTextConf);
+	}
+	
 	/**
 	 * getter for confidence - gets
 	 * 
@@ -131,6 +143,18 @@ public class AggregateConfidence extends Annotation {
 		if (AggregateConfidence_Type.featOkTst && ((AggregateConfidence_Type) jcasType).casFeat_confidence == null)
 			jcasType.jcas.throwFeatMissing("confidence", "edu.rosehulman.aixprize.pipeline.types.AggregateConfidence");
 		jcasType.ll_cas.ll_setDoubleValue(addr, ((AggregateConfidence_Type) jcasType).casFeatCode_confidence, v);
+	}
+	
+	public void setNormPointingConf(double v) {
+		if (AggregateConfidence_Type.featOkTst && ((AggregateConfidence_Type) jcasType).casFeat_normPointingConf == null)
+			jcasType.jcas.throwFeatMissing("normPointingConf", "edu.rosehulman.aixprize.pipeline.types.AggregateConfidence");
+		jcasType.ll_cas.ll_setDoubleValue(addr, ((AggregateConfidence_Type) jcasType).casFeatCode_normPointingConf, v);
+	}
+	
+	public void setNormTextConf(double v) {
+		if (AggregateConfidence_Type.featOkTst && ((AggregateConfidence_Type) jcasType).casFeat_normTextConf == null)
+			jcasType.jcas.throwFeatMissing("normTextConf", "edu.rosehulman.aixprize.pipeline.types.AggregateConfidence");
+		jcasType.ll_cas.ll_setDoubleValue(addr, ((AggregateConfidence_Type) jcasType).casFeatCode_normTextConf, v);
 	}
 	
 	/**

--- a/src/main/java/edu/rosehulman/aixprize/pipeline/types/AggregateConfidence_Type.java
+++ b/src/main/java/edu/rosehulman/aixprize/pipeline/types/AggregateConfidence_Type.java
@@ -24,11 +24,21 @@ public class AggregateConfidence_Type extends Annotation_Type {
 	final Feature casFeat_id;
 	/** @generated */
 	final int casFeatCode_id;
-	
+
 	/** @generated */
 	final Feature casFeat_confidence;
 	/** @generated */
 	final int casFeatCode_confidence;
+
+	/** @generated */
+	final Feature casFeat_normPointingConf;
+	/** @generated */
+	final int casFeatCode_normPointingConf;
+
+	/** @generated */
+	final Feature casFeat_normTextConf;
+	/** @generated */
+	final int casFeatCode_normTextConf;
 
 	/**
 	 * @generated
@@ -41,7 +51,19 @@ public class AggregateConfidence_Type extends Annotation_Type {
 			jcas.throwFeatMissing("confidence", "edu.rosehulman.aixprize.pipeline.types.AggregateConfidence");
 		return ll_cas.ll_getDoubleValue(addr, casFeatCode_confidence);
 	}
-	
+
+	public double getNormPointingConf(int addr) {
+		if (featOkTst && casFeat_normPointingConf == null)
+			jcas.throwFeatMissing("normPointingConf", "edu.rosehulman.aixprize.pipeline.types.AggregateConfidence");
+		return ll_cas.ll_getDoubleValue(addr, casFeatCode_normPointingConf);
+	}
+
+	public double getNormTextConf(int addr) {
+		if (featOkTst && casFeat_normTextConf == null)
+			jcas.throwFeatMissing("normTextConf", "edu.rosehulman.aixprize.pipeline.types.AggregateConfidence");
+		return ll_cas.ll_getDoubleValue(addr, casFeatCode_normTextConf);
+	}
+
 	/**
 	 * @generated
 	 * @param addr
@@ -61,12 +83,24 @@ public class AggregateConfidence_Type extends Annotation_Type {
 	 * @param v
 	 *            value to set
 	 */
-	public void setConfidece(int addr, double v) {
+	public void setConfidence(int addr, double v) {
 		if (featOkTst && casFeat_confidence == null)
 			jcas.throwFeatMissing("confidence", "edu.rosehulman.aixprize.pipeline.types.AggregateConfidence");
 		ll_cas.ll_setDoubleValue(addr, casFeatCode_confidence, v);
 	}
 	
+	public void setNormPointingConf(int addr, double v) {
+		if (featOkTst && casFeat_normPointingConf == null)
+			jcas.throwFeatMissing("normPointingConf", "edu.rosehulman.aixprize.pipeline.types.AggregateConfidence");
+		ll_cas.ll_setDoubleValue(addr, casFeatCode_normPointingConf, v);
+	}
+	
+	public void setNormTextConf(int addr, double v) {
+		if (featOkTst && casFeat_normTextConf == null)
+			jcas.throwFeatMissing("normTextConf", "edu.rosehulman.aixprize.pipeline.types.AggregateConfidence");
+		ll_cas.ll_setDoubleValue(addr, casFeatCode_normTextConf, v);
+	}
+
 	/**
 	 * @generated
 	 * @param addr
@@ -94,12 +128,18 @@ public class AggregateConfidence_Type extends Annotation_Type {
 		casImpl.getFSClassRegistry().addGeneratorForType((TypeImpl) this.casType, getFSGenerator());
 
 		casFeat_id = jcas.getRequiredFeatureDE(casType, "id", "uima.cas.Double", featOkTst);
-		casFeatCode_id = (null == casFeat_id) ? JCas.INVALID_FEATURE_CODE
-				: ((FeatureImpl) casFeat_id).getCode();
-		
+		casFeatCode_id = (null == casFeat_id) ? JCas.INVALID_FEATURE_CODE : ((FeatureImpl) casFeat_id).getCode();
+
 		casFeat_confidence = jcas.getRequiredFeatureDE(casType, "confidence", "uima.cas.Double", featOkTst);
 		casFeatCode_confidence = (null == casFeat_confidence) ? JCas.INVALID_FEATURE_CODE
 				: ((FeatureImpl) casFeat_confidence).getCode();
-
+		
+		casFeat_normPointingConf = jcas.getRequiredFeatureDE(casType, "normPointingConf", "uima.cas.Double", featOkTst);
+		casFeatCode_normPointingConf = (null == casFeat_normPointingConf) ? JCas.INVALID_FEATURE_CODE
+				: ((FeatureImpl) casFeat_normPointingConf).getCode();
+		
+		casFeat_normTextConf = jcas.getRequiredFeatureDE(casType, "normTextConf", "uima.cas.Double", featOkTst);
+		casFeatCode_normTextConf = (null == casFeat_normTextConf) ? JCas.INVALID_FEATURE_CODE
+				: ((FeatureImpl) casFeat_normTextConf).getCode();
 	}
 }

--- a/src/main/java/edu/rosehulman/aixprize/pipeline/types/FilteredBlock.java
+++ b/src/main/java/edu/rosehulman/aixprize/pipeline/types/FilteredBlock.java
@@ -1,0 +1,148 @@
+package edu.rosehulman.aixprize.pipeline.types;
+
+import org.apache.uima.jcas.JCas;
+import org.apache.uima.jcas.JCasRegistry;
+import org.apache.uima.jcas.cas.TOP_Type;
+import org.apache.uima.jcas.tcas.Annotation;
+
+public class FilteredBlock extends Annotation {
+
+	/**
+	 * @generated
+	 * @ordered
+	 */
+	@SuppressWarnings("hiding")
+	public final static String _TypeName = "edu.rosehulman.aixprize.pipeline.types.FilteredBlock";
+
+	/**
+	 * @generated
+	 * @ordered
+	 */
+	@SuppressWarnings("hiding")
+	public final static int typeIndexID = JCasRegistry.register(FilteredBlock.class);
+	/**
+	 * @generated
+	 * @ordered
+	 */
+	@SuppressWarnings("hiding")
+	public final static int type = typeIndexID;
+
+	/**
+	 * @generated
+	 * @return index of the type
+	 */
+	@Override
+	public int getTypeIndexID() {
+		return typeIndexID;
+	}
+
+	/**
+	 * Never called. Disable default constructor
+	 * 
+	 * @generated
+	 */
+	protected FilteredBlock() {
+		/* intentionally empty block */}
+
+	/**
+	 * Internal - constructor used by generator
+	 * 
+	 * @generated
+	 * @param casImpl
+	 *            the CAS this Feature Structure belongs to
+	 * @param type
+	 *            the type of this Feature Structure
+	 */
+	public FilteredBlock(int addr, TOP_Type type) {
+		super(addr, type);
+		readObject();
+	}
+
+	/**
+	 * @generated
+	 * @param jcas
+	 *            JCas to which this Feature Structure belongs
+	 */
+	public FilteredBlock(JCas jcas) {
+		super(jcas);
+		readObject();
+	}
+
+	/**
+	 * @generated
+	 * @param jcas
+	 *            JCas to which this Feature Structure belongs
+	 * @param begin
+	 *            offset to the begin spot in the SofA
+	 * @param end
+	 *            offset to the end spot in the SofA
+	 */
+	public FilteredBlock(JCas jcas, int begin, int end) {
+		super(jcas);
+		setBegin(begin);
+		setEnd(end);
+		readObject();
+	}
+
+	/**
+	 * <!-- begin-user-doc --> Write your own initialization here <!-- end-user-doc
+	 * -->
+	 *
+	 * @generated modifiable
+	 */
+	private void readObject() {
+		/* default - does nothing empty block */}
+
+	// *--------------*
+	// * Feature: isSelectedBlock
+
+	/**
+	 * getter for isSelectedBlock - gets
+	 * 
+	 * @generated
+	 * @return value of the feature
+	 */
+	public double getIsSelectedBlock() {
+		if (FilteredBlock_Type.featOkTst && ((FilteredBlock_Type) jcasType).casFeat_isSelectedBlock == null)
+			jcasType.jcas.throwFeatMissing("isSelectedBlock", "edu.rosehulman.aixprize.pipeline.types.FilteredBlock");
+		return jcasType.ll_cas.ll_getDoubleValue(addr, ((FilteredBlock_Type) jcasType).casFeatCode_isSelectedBlock);
+	}
+	
+	/**
+	 * getter for isSelectedBlock - gets
+	 * 
+	 * @generated
+	 * @return value of the feature
+	 */
+	public double getId() {
+		if (FilteredBlock_Type.featOkTst && ((FilteredBlock_Type) jcasType).casFeat_id == null)
+			jcasType.jcas.throwFeatMissing("id", "edu.rosehulman.aixprize.pipeline.types.FilteredBlock");
+		return jcasType.ll_cas.ll_getDoubleValue(addr, ((FilteredBlock_Type) jcasType).casFeatCode_id);
+	}
+
+	/**
+	 * setter for isSelectedBlock - sets
+	 * 
+	 * @generated
+	 * @param v
+	 *            value to set into the feature
+	 */
+	public void setIsSelectedBlock(double v) {
+		if (FilteredBlock_Type.featOkTst && ((FilteredBlock_Type) jcasType).casFeat_isSelectedBlock == null)
+			jcasType.jcas.throwFeatMissing("isSelectedBlock", "edu.rosehulman.aixprize.pipeline.types.FilteredBlock");
+		jcasType.ll_cas.ll_setDoubleValue(addr, ((FilteredBlock_Type) jcasType).casFeatCode_isSelectedBlock, v);
+	}
+	
+	/**
+	 * setter for isSelectedBlock - sets
+	 * 
+	 * @generated
+	 * @param v
+	 *            value to set into the feature
+	 */
+	public void setId(double v) {
+		if (FilteredBlock_Type.featOkTst && ((FilteredBlock_Type) jcasType).casFeat_id == null)
+			jcasType.jcas.throwFeatMissing("id", "edu.rosehulman.aixprize.pipeline.types.FilteredBlock");
+		jcasType.ll_cas.ll_setDoubleValue(addr, ((FilteredBlock_Type) jcasType).casFeatCode_id, v);
+	}
+}

--- a/src/main/java/edu/rosehulman/aixprize/pipeline/types/FilteredBlock_Type.java
+++ b/src/main/java/edu/rosehulman/aixprize/pipeline/types/FilteredBlock_Type.java
@@ -1,0 +1,101 @@
+package edu.rosehulman.aixprize.pipeline.types;
+
+import org.apache.uima.jcas.JCas;
+import org.apache.uima.jcas.JCasRegistry;
+import org.apache.uima.cas.impl.TypeImpl;
+import org.apache.uima.cas.Type;
+import org.apache.uima.cas.impl.FeatureImpl;
+import org.apache.uima.cas.Feature;
+import org.apache.uima.jcas.tcas.Annotation_Type;
+
+public class FilteredBlock_Type extends Annotation_Type {
+	/** @generated */
+	@SuppressWarnings("hiding")
+	public final static int typeIndexID = FilteredBlock.typeIndexID;
+	/**
+	 * @generated
+	 * @modifiable
+	 */
+	@SuppressWarnings("hiding")
+	public final static boolean featOkTst = JCasRegistry
+			.getFeatOkTst("edu.rosehulman.aixprize.pipeline.types.FilteredBlock");
+
+	final Feature casFeat_id;
+	final int casFeatCode_id;
+	
+	final Feature casFeat_isSelectedBlock;
+	final int casFeatCode_isSelectedBlock;
+
+	/**
+	 * @generated
+	 * @param addr
+	 *            low level Feature Structure reference
+	 * @return the feature value
+	 */
+	public double getIsSelectedBlock(int addr) {
+		if (featOkTst && casFeat_isSelectedBlock == null)
+			jcas.throwFeatMissing("isSelectedBlock", "edu.rosehulman.aixprize.pipeline.types.FilteredBlock");
+		return ll_cas.ll_getDoubleValue(addr, casFeatCode_isSelectedBlock);
+	}
+	
+	/**
+	 * @generated
+	 * @param addr
+	 *            low level Feature Structure reference
+	 * @return the feature value
+	 */
+	public double getId(int addr) {
+		if (featOkTst && casFeat_isSelectedBlock == null)
+			jcas.throwFeatMissing("id", "edu.rosehulman.aixprize.pipeline.types.FilteredBlock");
+		return ll_cas.ll_getDoubleValue(addr, casFeatCode_id);
+	}
+
+	/**
+	 * @generated
+	 * @param addr
+	 *            low level Feature Structure reference
+	 * @param v
+	 *            value to set
+	 */
+	public void setIsSelectedBlock(int addr, double v) {
+		if (featOkTst && casFeat_isSelectedBlock == null)
+			jcas.throwFeatMissing("isSelectedBlock", "edu.rosehulman.aixprize.pipeline.types.FilteredBlock");
+		ll_cas.ll_setDoubleValue(addr, casFeatCode_isSelectedBlock, v);
+	}
+	
+	/**
+	 * @generated
+	 * @param addr
+	 *            low level Feature Structure reference
+	 * @param v
+	 *            value to set
+	 */
+	public void setId(int addr, double v) {
+		if (featOkTst && casFeat_id == null)
+			jcas.throwFeatMissing("id", "edu.rosehulman.aixprize.pipeline.types.FilteredBlock");
+		ll_cas.ll_setDoubleValue(addr, casFeatCode_id, v);
+	}
+
+	/**
+	 * initialize variables to correspond with Cas Type and Features
+	 * 
+	 * @generated
+	 * @param jcas
+	 *            JCas
+	 * @param casType
+	 *            Type
+	 */
+	public FilteredBlock_Type(JCas jcas, Type casType) {
+		super(jcas, casType);
+		casImpl.getFSClassRegistry().addGeneratorForType((TypeImpl) this.casType, getFSGenerator());
+
+		casFeat_id = jcas.getRequiredFeatureDE(casType, "id", "uima.cas.Double", featOkTst);
+		casFeatCode_id = (null == casFeat_id) ? JCas.INVALID_FEATURE_CODE
+				: ((FeatureImpl) casFeat_id).getCode();
+		
+		casFeat_isSelectedBlock = jcas.getRequiredFeatureDE(casType, "isSelectedBlock", "uima.cas.Double", featOkTst);
+		casFeatCode_isSelectedBlock = (null == casFeat_isSelectedBlock) ? JCas.INVALID_FEATURE_CODE
+				: ((FeatureImpl) casFeat_isSelectedBlock).getCode();
+
+	}
+}


### PR DESCRIPTION
Added the Java code and XML descriptors for the text processing, aggregate confidence, and feedback units. Each change in isolation introduces several new files, but all of these files follow the format used for existing annotators. Hence, the amount of change is small relative to the lines of code changed.